### PR TITLE
fixed race condition

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -39,7 +39,6 @@
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-animate/angular-animate.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-    <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
     <!-- endinject -->
 
     <!-- inject:js -->

--- a/client/services/group/group.js
+++ b/client/services/group/group.js
@@ -2,6 +2,7 @@
 
 angular.module('eggercise')
   .service('GroupService', function ($rootScope, $q, $http) {
+    console.log('in groupservice');
     var service = {};
 
     service.showAllGroups = function () {
@@ -38,6 +39,7 @@ angular.module('eggercise')
 
     //show group by group id
     service.showGroup = function (id) {
+      console.log('reached showGroup');
       var deferred = $q.defer();
       $http.get('/api/groups/' + id)
         .success(function (showGroup) {

--- a/client/views/single_group/single.group.controller.js
+++ b/client/views/single_group/single.group.controller.js
@@ -18,7 +18,7 @@ angular.module('eggercise')
       vm.days;
       vm.daysBehind;
       vm.pot;
-      vm.othersDaysBehind;
+      console.log(vm);
 
       angular.extend(vm, {
 
@@ -53,6 +53,7 @@ angular.module('eggercise')
                   vm.exercises.push(data._members[i].exercises[j]);
                 }
               }
+              vm.moneyOwed(id);
             })
             .catch(function (err) {
               vm.error = err;
@@ -62,10 +63,14 @@ angular.module('eggercise')
 
         moneyOwed: function (id) {
           var user = Auth.getUser();
+          var daysDifference;
+          var runnerUp;
+
           GroupService.showGroup(id)
             .then(function (data) {
               data.you = user;
               data.leader = {email: 'leader@test.com', exercises: -1};
+
               for (var i = 0; i < data._members.length; i++) {
                 data._members[i].validExercises = [];
                 for(var j = 0; j < data._members[i].exercises.length; j++) {
@@ -81,18 +86,21 @@ angular.module('eggercise')
                 if(data._members[i].validExercises.length > data.leader.exercises) {
                   data.leader.email = data._members[i].email;
                   data.leader.exercises = data._members[i].validExercises.length;
-                  vm.days = data.leader.exercises - user.exercises.length;
-                  vm.youOwe = Math.abs(vm.days*vm.group.bet);
-                }
-                //Comparing current user to the leader of the group through e-mail
-                if(data.you.email == data.leader.email) {
-                  vm.daysAhead = Math.abs(vm.days);
-                  vm.pot = 'Wins ' + vm.youOwe;
-                } else {
-                  vm.daysBehind = Math.abs(vm.days);
-                  vm.pot = 'Pays ' + vm.youOwe;
                 }
               }
+              daysDifference = data.leader.exercises - user.exercises.length + 1;
+              vm.youOwe = Math.abs(daysDifference*vm.group.bet);
+
+              //Comparing current user to the leader of the group through e-mail
+              if(data.you.email == data.leader.email) {
+                vm.daysAhead = Math.abs(daysDifference);
+                vm.pot = 'Wins ' + vm.youOwe;
+              } else {
+                daysDifference = data.leader.exercises - user.exercises.length + 1;
+                vm.daysBehind = Math.abs(daysDifference);
+                vm.pot = 'Pays ' + vm.youOwe;
+              }
+
               vm.group = data;
             })
             .catch(function (err) {

--- a/client/views/single_group/singlegroup.html
+++ b/client/views/single_group/singlegroup.html
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-   <div ng-init="vm.moneyOwed(vm.group_id)"> 
+   <!-- <div ng-init="vm.moneyOwed(vm.group_id)">  -->
     <div class="col-xs-4">
       <div class="jumbotron">
         <div class="row">
@@ -67,7 +67,7 @@
         </div>
       </div>
     </div>
-  </div>
+  <!-- </div> -->
 
     <div class="col-xs-4">
       <div class="jumbotron">


### PR DESCRIPTION
When you are viewing a single group and refresh, you get errors due to race condition between moneyOwed and showGroup because they are using the same services and html is calling ng-init for these two functions. This is fixed by calling moneyOwed on the showGroup and getting rid of ng-init(vm.moneyOwed) in the html.
