### PR TITLE
Fix link in README (for Eggercise doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ At this point, you should have the app setup complete.
 
 ## Using Eggercise
 
-Refer to the Eggercise document [here](https://github.com/learntechlabs/eggercise/blob/readme/appDOC.md)
+Refer to the Eggercise document [here](appDOC.md)


### PR DESCRIPTION
- Change the absolute link to relative link in README.md for Eggercise document (appDOC.md).
